### PR TITLE
fix: skip regular .canvas files in standalone watcher

### DIFF
--- a/canvas-watcher.js
+++ b/canvas-watcher.js
@@ -189,6 +189,14 @@ function findLegendCard(nodes) {
   return nodes.find((n) => n.type === "text" && (n.text || "").startsWith("## Legend"));
 }
 
+function isWorkflowCanvas(canvas) {
+  const nodes = canvas.nodes || [];
+  const legend = findLegendCard(nodes);
+  if (!legend) return false;
+  const text = legend.text || "";
+  return text.includes("Red") && text.includes("Blocked");
+}
+
 function upsertStatusCard(canvas, cardId, title, items, color, slot) {
   const nodes = canvas.nodes;
   const existingIdx = nodes.findIndex((n) => n.id === cardId);
@@ -298,6 +306,12 @@ function processCanvas(filePath) {
     canvas = JSON.parse(raw);
   } catch {
     console.log(`  [skip] ${path.basename(filePath)} — invalid JSON`);
+    return;
+  }
+
+  // Only process Kanvas workflow canvases (must have Legend card with state keywords)
+  if (!isWorkflowCanvas(canvas)) {
+    console.log(`  [skip] ${path.basename(filePath)} — not a Kanvas workflow canvas`);
     return;
   }
 


### PR DESCRIPTION
Found a possible bug while using the standalone `canvas-watcher.js`.

Right now, it tries to process every single `.canvas` file it finds in the directory. This ends up completely messing up regular Obsidian canvases (like normal mind maps or notes) by injecting error/warning cards and rewriting the JSON.

The Obsidian plugin already has a guard for this, so I just ported the `isWorkflowCanvas()` check over to the standalone watcher. Now it safely skips any file that isn't an actual Kanvas workflow and just drops a log message.

Small fix, shouldn't change anything for actual workflows. Let me know if you need me to tweak anything!