### PR TITLE
fix: skip non-workflow canvases in standalone watcher

### DIFF
--- a/canvas-watcher.js
+++ b/canvas-watcher.js
@@ -189,6 +189,14 @@ function findLegendCard(nodes) {
   return nodes.find((n) => n.type === "text" && (n.text || "").startsWith("## Legend"));
 }
 
+function isWorkflowCanvas(canvas) {
+  const nodes = canvas.nodes || [];
+  const legend = findLegendCard(nodes);
+  if (!legend) return false;
+  const text = legend.text || "";
+  return text.includes("Red") && text.includes("Blocked");
+}
+
 function upsertStatusCard(canvas, cardId, title, items, color, slot) {
   const nodes = canvas.nodes;
   const existingIdx = nodes.findIndex((n) => n.id === cardId);
@@ -298,6 +306,12 @@ function processCanvas(filePath) {
     canvas = JSON.parse(raw);
   } catch {
     console.log(`  [skip] ${path.basename(filePath)} — invalid JSON`);
+    return;
+  }
+
+  // Only process Kanvas workflow canvases (must have Legend card with state keywords)
+  if (!isWorkflowCanvas(canvas)) {
+    console.log(`  [skip] ${path.basename(filePath)} — not a Kanvas workflow canvas`);
     return;
   }
 


### PR DESCRIPTION
Found a possible bug in `canvas-watcher.js`. It processes every `.canvas` file it finds, even if it's not a Kanvas board. So running it in a directory with regular Obsidian canvases (mind maps, notes, whatever) will inject Error/Warning cards, recolor nodes and rewrite their JSON, which is not great.

The Obsidian plugin already handles this with `isWorkflowCanvas()`, so I just ported the same check to the standalone watcher. Now it skips anything that doesn't have a Kanvas Legend card.