### PR TITLE
fix: only check for cycles in the relevant dependency path

### DIFF
--- a/canvas-tool.py
+++ b/canvas-tool.py
@@ -273,32 +273,24 @@ def build_adj(canvas):
 
 
 def has_cycle_with_edge(canvas, from_id, to_id):
-    """Check if adding edge from_id → to_id would create a cycle (DFS)."""
+    """Check if adding edge from_id -> to_id would create a cycle.
+
+    Only checks whether to_id can already reach from_id through existing
+    edges.  If it can, adding from_id -> to_id would close a loop.
+    """
+    if from_id == to_id:
+        return True
     adj = build_adj(canvas)
-    adj[from_id].append(to_id)
     visited = set()
-    rec_stack = set()
-
-    def dfs(nid):
+    stack = [to_id]
+    while stack:
+        nid = stack.pop()
+        if nid == from_id:
+            return True
+        if nid in visited:
+            continue
         visited.add(nid)
-        rec_stack.add(nid)
-        for neighbor in adj.get(nid, []):
-            if neighbor not in visited:
-                if dfs(neighbor):
-                    return True
-            elif neighbor in rec_stack:
-                return True
-        rec_stack.discard(nid)
-        return False
-
-    # Check from the from_id
-    all_nodes = set(adj.keys())
-    for v in adj.values():
-        all_nodes.update(v)
-    for nid in all_nodes:
-        if nid not in visited:
-            if dfs(nid):
-                return True
+        stack.extend(adj.get(nid, []))
     return False
 
 


### PR DESCRIPTION
Hey again! Found a potential bug where a single accidental cycle in Obsidian blocks dependency updates for the entire board.

The issue is that `has_cycle_with_edge()` runs a global DFS. If a cycle exists *anywhere*, it rejects all new edges — even completely unrelated ones — breaking `add-dep` and `batch` commands.

**Example:** Say your board has tasks A → B → C → A (a cycle someone drew by accident) and two unrelated tasks X → Y. If you try `add-dep Y Z`, the current code adds Y→Z to the graph, then runs DFS over *all* nodes. It hits A → B → C → A, finds a cycle, and rejects the Y→Z edge — even though Y and Z have nothing to do with A, B, or C.

This PR swaps the global DFS for a targeted reachability check: we just verify if `to_id` can already reach `from_id` through existing edges before adding the new one. Also threw in an early return for self-loops.

**Repro:**
1. Make a cycle in Obsidian (e.g., A → B → A).
2. Try `add-dep` on unrelated tasks X and Y.
3. Fails with a circular dependency error.

Saves a few lines of code too (-8 lines). Cheers!