### PR TITLE
Fix UTF-8 double-encoding in batch command on Windows

### DIFF
--- a/canvas-tool.py
+++ b/canvas-tool.py
@@ -68,6 +68,12 @@ import uuid
 import shutil
 from collections import defaultdict
 
+# Force UTF-8 for stdio on Windows (prevents double-encoding of non-ASCII text
+# when piping through bash heredocs or other shell constructs).
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -1031,7 +1037,7 @@ def cmd_batch(canvas, args, path):
     in the same batch by using the title as a reference (matched case-insensitively)
     in addition to existing task IDs on the board.
     """
-    raw = sys.stdin.read()
+    raw = sys.stdin.buffer.read().decode("utf-8")
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as e:


### PR DESCRIPTION
## Summary

- On Windows, `sys.stdin.read()` in `cmd_batch` uses the system encoding (CP1252) instead of UTF-8. When piping JSON with non-ASCII characters (accents, ñ, etc.) through bash heredocs, this causes **double-encoding**: e.g. `código` is stored as `cÃ³digo` in the canvas file.
- Fixed by reading stdin as raw bytes and decoding explicitly as UTF-8: `sys.stdin.buffer.read().decode("utf-8")`
- Also added early `reconfigure(encoding="utf-8")` for stdout/stderr at module level, complementing the existing `TextIOWrapper` approach in `main()` (line 1373). The existing check will simply skip if the stream is already UTF-8.

## Repro steps

1. On Windows (Git Bash), run a batch command with accented text:
```bash
echo '{"groups":[],"tasks":[{"group":"Dev","title":"Código función","desc":"Descripción"}]}' | python canvas-tool.py "Project.canvas" batch
```
2. **Before fix:** The canvas file contains `cÃ³digo funciÃ³n` and `DescripciÃ³n` (double-encoded UTF-8)
3. **After fix:** The canvas file correctly contains `código función` and `Descripción`

## Root cause

`sys.stdin.read()` on Windows defaults to CP1252 encoding. UTF-8 bytes like `c3 b3` (ó) get interpreted as two CP1252 characters (`Ã³`), then re-encoded to UTF-8 when written to the canvas file, producing `c3 83 c2 b3` — the classic double-encoding pattern.

## Test plan

- [x] Verified on Windows 11 with Git Bash
- [x] `batch` command with Spanish accents (á, é, í, ó, ú, ñ) produces correct UTF-8 in canvas file
- [x] Existing `propose` command (uses argparse, not stdin) unaffected
- [x] Compatible with existing `TextIOWrapper` guard in `main()` — no conflict

Related: #20 (Windows shell issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)