### PR TITLE
feat: DAG-aware layout command with dynamic card sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ python canvas-tool.py "<file>.canvas" <command> [args]
 | `batch` | Bulk-add from JSON on stdin |
 | `add-dep <FROM> <TO>` | New dependency edge |
 | `normalize` | Assign IDs, fix blocked states |
+| `layout` | Reposition all tasks by DAG depth; resize and reflow groups |
 
 No delete, no done, no raw JSON editing — by design.
 

--- a/canvas-tool.py
+++ b/canvas-tool.py
@@ -1369,12 +1369,18 @@ def cmd_layout(canvas, _args, path):
             (g.get("y", 0) + g.get("height", 700) / 2 - ty) ** 2
         ), default=None)
 
+    # Phase 1: assign all tasks to groups BEFORE repositioning anything.
+    # This must happen in one pass so that tasks moved by an earlier group's
+    # layout don't get re-claimed by a later group whose bounds they now overlap.
     nodes_by_group_id = {}
+    for group in groups:
+        nodes_by_group_id[group["id"]] = [t for t in tasks if _assign_group(t) == group]
+
     moved = 0
 
+    # Phase 2: reposition tasks within each group
     for group in groups:
-        group_tasks = [t for t in tasks if _assign_group(t) == group]
-        nodes_by_group_id[group["id"]] = group_tasks
+        group_tasks = nodes_by_group_id.get(group["id"], [])
         if not group_tasks:
             continue
 

--- a/canvas-tool.py
+++ b/canvas-tool.py
@@ -66,6 +66,7 @@ import json
 import sys
 import os
 import re
+import math
 import argparse
 import uuid
 import shutil
@@ -275,6 +276,36 @@ def build_adj(canvas):
     return adj
 
 
+def compute_depths(canvas):
+    """Compute global longest-path depth for every task node.
+
+    depth(root) = 0; depth(t) = max(depth(parent) + 1 for each parent).
+    Only edges between task nodes are considered.
+    Returns a dict {node_id: depth}.
+    """
+    tasks = get_tasks(canvas)
+    task_ids = {t["id"] for t in tasks}
+    parents = defaultdict(list)
+    for e in canvas.get("edges", []):
+        fn, tn = e.get("fromNode"), e.get("toNode")
+        if fn in task_ids and tn in task_ids:
+            parents[tn].append(fn)
+
+    depths = {}
+
+    def _depth(nid):
+        if nid in depths:
+            return depths[nid]
+        depths[nid] = 0  # mark in-progress (cycle guard)
+        if parents[nid]:
+            depths[nid] = max(_depth(p) for p in parents[nid]) + 1
+        return depths[nid]
+
+    for t in tasks:
+        _depth(t["id"])
+    return depths
+
+
 def has_cycle_with_edge(canvas, from_id, to_id):
     """Check if adding edge from_id -> to_id would create a cycle.
 
@@ -427,7 +458,65 @@ def compute_group_placement(canvas, width=380, height=700):
     return int(new_x), int(new_y)
 
 
-def compute_placement(canvas, group, depends_on_nodes=None, card_w=280, card_h=160):
+def _card_size(text):
+    """Estimate card (width, height) from markdown card text.
+
+    Card text format:
+        ## ID Title
+        [blank line]
+        Description body, possibly multi-line.
+
+    Rendering assumptions (Obsidian Canvas, default zoom):
+        - ~8px per character (proportional font approximation)
+        - H2 title: ~22px line height
+        - Body text: ~18px line height
+        - Horizontal padding: 16px each side (32px total)
+        - Vertical padding: 40px total (top+bottom)
+        - Gap between title and body: 12px
+    """
+    CHAR_W   = 8
+    H_PAD    = 32   # left + right padding
+    V_PAD    = 40   # top + bottom padding
+    TITLE_LH = 22   # H2 line height
+    BODY_LH  = 18   # body line height
+    GAP      = 12   # space between title block and body
+
+    MIN_W, MAX_W = 280, 520
+    MIN_H        = 120
+
+    lines = text.split('\n')
+    title = ''
+    body_paragraphs = []
+    for line in lines:
+        if line.startswith('## '):
+            title = line[3:].strip()
+        elif title:
+            body_paragraphs.append(line)
+
+    # Width driven by title length; body wraps inside
+    card_w = max(MIN_W, min(MAX_W, len(title) * CHAR_W + H_PAD + 16))
+
+    chars_per_line = max(1, (card_w - H_PAD) // CHAR_W)
+
+    # Title lines
+    title_lines = math.ceil(len(title) / chars_per_line) if title else 1
+    title_h = title_lines * TITLE_LH
+
+    # Body lines (paragraph-aware; blank lines count as 1)
+    body_line_count = 0
+    for para in body_paragraphs:
+        if para.strip():
+            body_line_count += math.ceil(len(para) / chars_per_line)
+        else:
+            body_line_count += 1
+    body_h = body_line_count * BODY_LH
+
+    card_h = max(MIN_H, V_PAD + title_h + (GAP + body_h if body_h else 0))
+
+    return int(card_w), int(card_h)
+
+
+def compute_placement(canvas, group, depends_on_nodes=None, card_w=360, card_h=200):
     """Compute (x, y) for a new card inside a group.
 
     Rules:
@@ -947,11 +1036,10 @@ def _create_proposed_task(canvas, group, title, desc, depends_on_ids=None):
                 error(f"Dependency task '{did}' not found")
             dep_nodes.append(dnode)
 
-    card_w, card_h = 280, 160
-    new_x, new_y = compute_placement(canvas, group, dep_nodes or None, card_w, card_h)
-
     node_id = uuid.uuid4().hex[:8]
     text = f"## {task_id} {title}\n{desc}"
+    card_w, card_h = _card_size(text)
+    new_x, new_y = compute_placement(canvas, group, dep_nodes or None, card_w, card_h)
 
     new_node = {
         "id": node_id,
@@ -1239,6 +1327,127 @@ def cmd_add_dep(canvas, args, path):
 # ---------------------------------------------------------------------------
 
 
+def cmd_layout(canvas, _args, path):
+    """Reposition all tasks using DAG depth for top-to-bottom dependency flow.
+
+    Within each group tasks are compacted into rows by depth. Same-depth
+    tasks are arranged in columns (max MAX_COLS per row, wrapping to the
+    next sub-row). Groups are repositioned after resize to prevent overlap.
+    Edge attachment sides are recomputed after nodes move.
+    """
+    tasks = get_tasks(canvas)
+    if not tasks:
+        print("No tasks to lay out.")
+        return
+
+    depths = compute_depths(canvas)
+    groups = get_groups(canvas)
+    node_by_id = {n["id"]: n for n in canvas.get("nodes", [])}
+
+    CARD_W    = 360   # fallback card width (used when text is unavailable)
+    CARD_H    = 200   # fallback card height
+    ROW_GAP   = 80    # vertical gap between rows
+    COL_GAP   = 60    # horizontal gap between cards in a row
+    TOP_PAD   = 140   # space reserved for the group label
+    LEFT_PAD  = 120   # left inner margin
+    RIGHT_PAD = 120   # right inner margin
+    BOT_PAD   = 120   # bottom inner margin
+    MAX_COLS  = 3     # max cards per row before wrapping
+    GROUP_GAP = 150   # gap between groups after repositioning
+
+    # Assign each task to a group. Tasks geometrically outside all groups
+    # (strays from a prior layout run) fall back to the nearest group by
+    # center distance so they are always recaptured.
+    def _assign_group(t):
+        g = get_group_for_node(canvas, t)
+        if g is not None:
+            return g
+        tx = t.get("x", 0) + t.get("width", 280) / 2
+        ty = t.get("y", 0) + t.get("height", 160) / 2
+        return min(groups, key=lambda g: (
+            (g.get("x", 0) + g.get("width", 380) / 2 - tx) ** 2 +
+            (g.get("y", 0) + g.get("height", 700) / 2 - ty) ** 2
+        ), default=None)
+
+    nodes_by_group_id = {}
+    moved = 0
+
+    for group in groups:
+        group_tasks = [t for t in tasks if _assign_group(t) == group]
+        nodes_by_group_id[group["id"]] = group_tasks
+        if not group_tasks:
+            continue
+
+        gx, gy = int(group.get("x", 0)), int(group.get("y", 0))
+
+        # Bucket by depth; sort each bucket by current x then task ID (stable)
+        by_depth = defaultdict(list)
+        for t in group_tasks:
+            by_depth[depths[t["id"]]].append(t)
+        for layer in by_depth.values():
+            layer.sort(key=lambda t: (t.get("x", 0), task_id_str(t) or t["id"]))
+
+        cur_y = gy + TOP_PAD
+        max_right = gx + LEFT_PAD
+
+        for d in sorted(by_depth.keys()):
+            layer = by_depth[d]
+            for chunk in [layer[i:i + MAX_COLS] for i in range(0, len(layer), MAX_COLS)]:
+                # Size each card dynamically from its text content
+                for t in chunk:
+                    w, h = _card_size(t.get("text", ""))
+                    t["width"] = w
+                    t["height"] = h
+                row_h = max(int(t.get("height", CARD_H)) for t in chunk)
+                col_x = gx + LEFT_PAD
+                for t in chunk:
+                    t["x"] = col_x
+                    t["y"] = cur_y
+                    w = int(t.get("width", CARD_W))
+                    max_right = max(max_right, col_x + w)
+                    col_x += w + COL_GAP
+                    moved += 1
+                cur_y += row_h + ROW_GAP
+
+        group["width"]  = max_right - gx + RIGHT_PAD
+        group["height"] = cur_y - gy + BOT_PAD
+
+    # Reposition groups to eliminate overlap using collision detection.
+    # Sort by original x so we preserve the intended left-to-right order.
+    placed = []
+    for group in sorted(groups, key=lambda g: g.get("x", 0)):
+        if not nodes_by_group_id.get(group["id"]):
+            continue
+        gx = int(group.get("x", 0))
+        gy = int(group.get("y", 0))
+        gw = int(group.get("width", 400))
+        gh = int(group.get("height", 200))
+        new_x = gx
+        for prev in placed:
+            px, py = int(prev.get("x", 0)), int(prev.get("y", 0))
+            pw, ph = int(prev.get("width", 400)), int(prev.get("height", 200))
+            if _cards_overlap(new_x, gy, gw, gh, px, py, pw, ph, margin=GROUP_GAP):
+                new_x = max(new_x, px + pw + GROUP_GAP)
+        dx = new_x - gx
+        if dx:
+            group["x"] = new_x
+            for t in nodes_by_group_id[group["id"]]:
+                t["x"] = int(t.get("x", 0)) + dx
+        placed.append(group)
+
+    # Recompute edge attachment sides now that nodes have moved
+    for e in canvas.get("edges", []):
+        fn = node_by_id.get(e.get("fromNode"))
+        tn = node_by_id.get(e.get("toNode"))
+        if fn and tn:
+            fs, ts = pick_sides(fn, tn)
+            e["fromSide"] = fs
+            e["toSide"] = ts
+
+    save_canvas(path, canvas)
+    print(f"Layout applied: {moved} tasks repositioned across {len(groups)} groups.")
+
+
 def cmd_normalize(canvas, _args, path):
     """Run normalization and save."""
     changes = normalize(canvas)
@@ -1428,6 +1637,7 @@ def build_parser():
     p_dep.add_argument("to_id", help="Blocked task ID")
 
     # Maintenance
+    sub.add_parser("layout", help="Reposition tasks by DAG depth (top-to-bottom flow)")
     sub.add_parser("normalize", help="Run normalization")
 
     return parser
@@ -1480,6 +1690,7 @@ def main():
         "batch": cmd_batch,
         "edit": cmd_edit,
         "add-dep": cmd_add_dep,
+        "layout": cmd_layout,
         "normalize": cmd_normalize,
     }
 

--- a/canvas-tool.py
+++ b/canvas-tool.py
@@ -461,59 +461,75 @@ def compute_group_placement(canvas, width=380, height=700):
 def _card_size(text):
     """Estimate card (width, height) from markdown card text.
 
-    Card text format:
-        ## ID Title
-        [blank line]
-        Description body, possibly multi-line.
+    Strategy: treat all text as a single pixel ribbon (title_chars × TITLE_CW
+    + body_chars × BODY_CW), then solve for the wrapping width that gives the
+    target aspect ratio. The quadratic comes from:
 
-    Rendering assumptions (Obsidian Canvas, default zoom):
-        - ~8px per character (proportional font approximation)
-        - H2 title: ~22px line height
-        - Body text: ~18px line height
-        - Horizontal padding: 16px each side (32px total)
-        - Vertical padding: 40px total (top+bottom)
-        - Gap between title and body: 12px
+        card_w / card_h = TARGET_RATIO
+        card_h = total_px_ribbon * AVG_LH / text_w + V_PAD
+        card_w = text_w + H_PAD
+
+    Substituting and rearranging gives:
+        text_w² + (H_PAD - R*V_PAD)*text_w - R*total_px*AVG_LH = 0
+
+    All font/padding constants are scaled to match Obsidian Canvas rendering
+    at default zoom (empirically calibrated). No separate scale factor is
+    applied — the constants themselves encode the true pixel sizes.
     """
-    CHAR_W   = 8
-    H_PAD    = 32   # left + right padding
-    V_PAD    = 40   # top + bottom padding
-    TITLE_LH = 22   # H2 line height
-    BODY_LH  = 18   # body line height
-    GAP      = 12   # space between title block and body
+    TITLE_CW     = 24   # H2 char width  (16px × 1.5 Obsidian scale)
+    BODY_CW      = 18   # body char width (12px × 1.5)
+    TITLE_LH     = 54   # H2 line height  (36px × 1.5)
+    BODY_LH      = 39   # body line height(26px × 1.5)
+    GAP          = 18   # gap between title and body (12px × 1.5)
+    H_PAD        = 60   # total horizontal padding    (40px × 1.5)
+    V_PAD        = 120  # total vertical overhead     (80px × 1.5)
+    TARGET_RATIO = 1.6  # target width / height
 
-    MIN_W, MAX_W = 280, 520
-    MIN_H        = 120
+    MIN_W, MAX_W = 450, 840
+    MIN_H        = 300
 
     lines = text.split('\n')
     title = ''
-    body_paragraphs = []
+    body_paragraphs = []   # preserve paragraph structure for hard-break counting
     for line in lines:
         if line.startswith('## '):
             title = line[3:].strip()
         elif title:
             body_paragraphs.append(line)
 
-    # Width driven by title length; body wraps inside
-    card_w = max(MIN_W, min(MAX_W, len(title) * CHAR_W + H_PAD + 16))
+    # Total pixel widths used for the quadratic (flat ribbon approximation)
+    title_px  = len(title) * TITLE_CW
+    body_flat = sum(len(p) for p in body_paragraphs)
+    body_px   = body_flat * BODY_CW
+    total_px  = title_px + body_px
 
-    chars_per_line = max(1, (card_w - H_PAD) // CHAR_W)
+    if total_px == 0:
+        return MIN_W, MIN_H
 
-    # Title lines
-    title_lines = math.ceil(len(title) / chars_per_line) if title else 1
-    title_h = title_lines * TITLE_LH
+    # Weighted average line height for the quadratic
+    avg_lh = (title_px * TITLE_LH + body_px * BODY_LH) // total_px if total_px else TITLE_LH
 
-    # Body lines (paragraph-aware; blank lines count as 1)
-    body_line_count = 0
+    # Solve quadratic for text-area width at TARGET_RATIO
+    b = H_PAD - TARGET_RATIO * V_PAD
+    c = -(TARGET_RATIO * total_px * avg_lh)
+    text_w = (-b + math.sqrt(b * b - 4 * c)) / 2   # a=1
+
+    card_w = int(max(MIN_W, min(MAX_W, text_w + H_PAD)))
+    actual_tw = max(1, card_w - H_PAD)
+
+    # Height from actual wrapping — paragraph-aware for body to handle hard breaks
+    title_lines = math.ceil(title_px / actual_tw) if title else 1
+    body_lines = 0
     for para in body_paragraphs:
         if para.strip():
-            body_line_count += math.ceil(len(para) / chars_per_line)
+            body_lines += math.ceil(len(para) * BODY_CW / actual_tw)
         else:
-            body_line_count += 1
-    body_h = body_line_count * BODY_LH
+            body_lines += 1  # blank line is an explicit hard break
 
-    card_h = max(MIN_H, V_PAD + title_h + (GAP + body_h if body_h else 0))
+    card_h = int(max(MIN_H, V_PAD + title_lines * TITLE_LH +
+                     (GAP + body_lines * BODY_LH if body_lines else 0)))
 
-    return int(card_w), int(card_h)
+    return card_w, card_h
 
 
 def compute_placement(canvas, group, depends_on_nodes=None, card_w=360, card_h=200):


### PR DESCRIPTION
## Summary

Adds a `layout` command that repositions all task cards on the canvas based on their position in the dependency DAG, and sizes each card to fit its content.

### How it works

**DAG layout:**
- Computes global longest-path depth for every task (cross-group dependencies are respected — if task A in group 1 blocks task B in group 2, B gets a later depth)
- Within each group, tasks are bucketed by depth and arranged in rows (max 3 per row, wrapping to sub-rows)
- Groups are resized to fit their tasks, then repositioned left-to-right with collision detection
- Edge attachment sides are recomputed after nodes move

**Dynamic card sizing (`_card_size`):**
- Treats title (H2) and body as pixel ribbons with separate char widths
- Solves a quadratic for the wrapping width that achieves a 1.6:1 aspect ratio
- Height is computed from paragraph-aware wrapping (blank lines count as hard breaks)
- Constants calibrated empirically to Obsidian Canvas default rendering

**Bug fixed:**
- Two-phase group assignment: tasks are assigned to groups in one pass *before* any coordinates change. Previously, tasks repositioned by an earlier group could be re-claimed by a later group whose bounds they now overlapped.

## Usage

```bash
python canvas-tool.py "Project.canvas" layout
```

Explicit command only — layout is destructive (repositions everything), so it is never run automatically.

## Test plan

- [ ] Run `layout` on a board with tasks in multiple groups — verify each task lands in its correct group
- [ ] Run `layout` on a board with cross-group dependencies — verify dependent tasks appear at greater depth
- [ ] Run `layout` twice — verify output is stable (idempotent)
- [ ] Verify card text is not clipped in Obsidian after layout